### PR TITLE
chore: Remove martin from reviewers so he's not flooded by notifications

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,6 @@ approvers:
   - tumido
   - vpavlin
   - pacospace
-  - martinpovolny
 
 reviewers:
   - 4n4nd
@@ -13,6 +12,5 @@ reviewers:
   - hemajv
   - HumairAK
   - tumido
-  - martinpovolny
   - vpavlin
   - pacospace


### PR DESCRIPTION
Let's relieve this poor man's inbox pressure! This change makes sesheta stop assigning @martinpovolny to reviews and PRs (yes, I had to tag him here for the last time :smirk: :grin: ). 